### PR TITLE
Handle content type

### DIFF
--- a/client.js
+++ b/client.js
@@ -141,9 +141,8 @@ class Client {
                         || response.body instanceof Buffer)
                 ) {
                     try {
-                        switch (response.headers['content-type']) {
+                        switch (getContentType(response)) {
                             case 'application/json':
-                            case 'application/json; charset=utf-8':
                             case 'text/javascript':
                                 response.body = JSON.parse(response.body);
                                 break;
@@ -334,6 +333,14 @@ function getTokensFromAuthorizationCode(cb) {
             this.setTokens(res.body);
             return res.body;
         })
+};
+
+function getContentType(response) {
+    if (typeof response.headers['content-type'] === 'string') {
+        const types = response.headers['content-type'].split(';')
+        return types[0].trim()
+    }
+    return response.headers['content-type']
 };
 
 module.exports = Client;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-api-client",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "lightweight Api client handling OAuth2 authentication",
   "main": "client.js",
   "scripts": {


### PR DESCRIPTION
Better parse a response's content type (split semi-colon) in order to handle charset case, such as "application/json; charset=utf-8", "application/json;charset=UTF-8", ...